### PR TITLE
Minor fix to the OWL API systemd service.

### DIFF
--- a/scripts/owl-api.service
+++ b/scripts/owl-api.service
@@ -1,8 +1,9 @@
 [Service]
 ExecStart=/usr/bin/nodejs /srv/owl/api/bin/www
+WorkingDirectory=/srv/owl/api
 Restart=always
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=owl-api
 User=www-data
 Group=www-data


### PR DESCRIPTION
Sets the working directory for the API service to the right path. This is needed for upcoming changes [to the API](https://github.com/pingdynasty/OwlServer/tree/feat-public-api/web/api).

As an additional but unrelated improvement, I've made the API log into the systemd logs instead of into the syslog.